### PR TITLE
Fixes for sample entropy

### DIFF
--- a/entropy.py
+++ b/entropy.py
@@ -130,7 +130,7 @@ def entropy(x, dim, r, n=1, scale=True, remove_baseline=False):
 
             count[i] = np.sum(sim) - 1
 
-        phi[j] = np.mean(count) / (N-m-1)
+        phi[j] = np.mean(count) / (N-dim-1)
 
     return np.log(phi[0] / phi[1])
 

--- a/entropy.py
+++ b/entropy.py
@@ -96,10 +96,11 @@ def entropy(x, dim, r, n=1, scale=True, remove_baseline=False):
     phi = [0, 0]  # phi(m), phi(m+1)
     for j in [0, 1]:
         m = dim + j
+        npat = N-dim
         if cross:
-            patterns = [pattern_mat(x[0], m), pattern_mat(x[1], m)]
+            patterns = [pattern_mat(x[0], m)[:, :npat], pattern_mat(x[1], m)[:, :npat]]
         else:
-            patterns = pattern_mat(x, m)
+            patterns = pattern_mat(x, m)[:, :npat]
 
         if remove_baseline:
             if cross:
@@ -108,8 +109,8 @@ def entropy(x, dim, r, n=1, scale=True, remove_baseline=False):
             else:
                 patterns = _remove_baseline(patterns, axis=0)
 
-        count = np.zeros(N-m)
-        for i in range(N-m):
+        count = np.zeros(npat)
+        for i in range(npat):
             if cross:
                 if m == 1:
                     sub = patterns[1][i]


### PR DESCRIPTION
@DominiqueMakowski called my attention to a discrepancy between this implementation of the sample entropy and my implementation in [nolds](https://github.com/CSchoel/nolds) in this issue:  https://github.com/neuropsychology/NeuroKit/issues/53 .

After an inspection of both code bases I believe that there are two small issues in entro-py that are fixed with this pull request:

* When we test template vectors of length m, we can only use vectors that we can follow for one more time step so that we have a corresponding vector of length m+1.
* `phi[i]` must be divided by `(N-dim-1)`, not `(N-m-1)`, otherwise we get a nonzero result if `phi[0] == phi[1]`.

I used the [original definition of SampEn by Richman and Moorman](https://doi.org/10.1152/ajpheart.2000.278.6.H2039) as reference.
